### PR TITLE
Allow chaining of set and save method.

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -17,7 +17,22 @@ class Repository extends BaseRepository
 
         parent::__construct(Config::get($name, []));
     }
+    
+    /**
+     * Return self to allow chain of set and save.
+     *
+     * @param array|string $key
+     * @param null $value
+     * 
+     * @return $this
+     */
+    public function set($key, $value = null)
+    {
+        parent::set($key, $value);
 
+        return $this;
+    }
+    
     public function save($from = null, $to = null, $validate = true)
     {
         if ($from === null) {


### PR DESCRIPTION
Allows code to be set and saved, simplified to one line.
```
$repository->set('foo', 'bar')->save();
```